### PR TITLE
self showed itself

### DIFF
--- a/b.rb
+++ b/b.rb
@@ -1,0 +1,23 @@
+require 'pry'
+
+animals = 
+  {"sugar glider"=>"Australia",
+    "aye-aye"=> "Madagascar",
+    "red-footed tortoise"=>"Panama",
+    "kangaroo"=> "Australia",
+    "tomato frog"=>"Madagascar",
+    "koala"=>"Australia"}
+
+class Hash
+  def keys_of(arg)
+    self.each do |key,value|
+      if value == arg
+      return key
+      end 
+        
+
+    end
+   
+  end
+end
+

--- a/lib/keys_of_hash.rb
+++ b/lib/keys_of_hash.rb
@@ -1,5 +1,30 @@
+require 'pry'
+
+animals = 
+  {"sugar glider"=>"Australia",
+    "aye-aye"=> "Madagascar",
+    "red-footed tortoise"=>"Panama",
+    "kangaroo"=> "Australia",
+    "tomato frog"=>"Madagascar",
+    "koala"=>"Australia"}
+
+def a 
+  {"sugar glider"=>"Australia",
+    "aye-aye"=> "Madagascar",
+    "red-footed tortoise"=>"Panama",
+    "kangaroo"=> "Australia",
+    "tomato frog"=>"Madagascar",
+    "koala"=>"Australia"}
+  end
+
 class Hash
-  def keys_of(arguments)
-    # code goes here
+  def keys_of(*arg)
+    self.select do |key, value| #research what .select returns I think it's a hash.
+      arg.include?(value)
+    end.keys #makes calling .keys make sense
   end
 end
+
+
+
+


### PR DESCRIPTION
Starting off with the code: 

```
class Hash
  def keys_of(*arg)
    self.select do |key, value| #research what .select returns I think it's a hash.
      arg.include?(value)
    end.keys #makes calling .keys make sense
  end
end
```

New things here:
- `(*arg)` the **splat operator** allows for multiple arguments. [For once Learn has a good resource for at least part of the lab.](https://endofline.wordpress.com/2011/01/21/the-strange-ruby-splat/) For the purposes of this lab all you need to know is that splat can allow for multiple arguments in this method. Something nifty you can do can be found here:

```
def say(what, *people)
  people.each{|person| puts "#{person}: #{what}"}
end
```

output:

```
say "Hello!", "Alice", "Bob", "Carl"
# Alice: Hello!
# Bob: Hello!
# Carl: Hello!
```

You can iterate over the multiple arguments, but that shouldn't be too mind blowing because you can iterate over an argument that is an array or hash.
- `self.select` I never knew what `self` was used for up until this lab. But this entire lab you were just creating a new method for the hash class, `keys_of`. So the hash `a` will be operated on by the `keys_of` hash method like so: `a.keys_of(*args)`. The way `self`plays into this, it is the referent of `a`.

```
self.select do |key, value|
```

Looking a this line of code we know that `(*args)` will equal something like "Australia" or "Panama" so the argument(s) for the method can't be iterated over, but `a` can be it's a hash. So it seems to me evidence that `self` refers to the object being operated on. 
**REMEMBER** the `.select` method is an enumerator that can be used on either hashes or arrays to return all items that meet the condition.
- `arg.include?(value)` This is important because normally `.include?` is reserved for objects like arrays and hashes. How are we doing this on strings? Well, using the splat operator puts all the arguments into what is essentially an array that can be iterated over, refer to point 1 for a little more information regarding this.
  - `end.keys` This controls the return value of this method as well as performs some minor formatting changes. Let's put it this way, all the items that are selected are hash key/value pairs. Without `.keys` you would get a hash with as many key/value pairs that were selected. When you use `.keys` you get an array of the keys of those pairs. So calling `.keys` will return only those keys, just like the lab wants.
